### PR TITLE
Fix: passport.socketio authorize failed `no session found`

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@
  * @Author: Hu Keyi
  * @Date: 2021-05-09 20:18:09
  * @Last Modified by: Hu Keyi
- * @Last Modified time: 2023-03-11 14:39:54
+ * @Last Modified time: 2023-03-18 17:46:55
  */
 
 /**
@@ -79,7 +79,8 @@ app.use(
 		secret: process.env.SESSION_SECRET,
 		resave: true,
 		saveUninitialized: true,
-		cookie: { secure: false }, // `secure: false` -> no need for https
+		cookie: { secure: false, httpOnly: false }, // `secure: false` -> no need for https
+		// httpOnly: false, 'cause client-side need to get cookie
 		store: store,
 		name: process.env.COOKIE_NAME, // name for the cookie to be stored in user's browser
 	})

--- a/server/configs/socket.config.js
+++ b/server/configs/socket.config.js
@@ -5,7 +5,7 @@
  * @Author: Hu Keyi
  * @Date: 2021-05-23 00:20:55
  * @Last Modified by: Hu Keyi
- * @Last Modified time: 2023-03-18 16:28:40
+ * @Last Modified time: 2023-03-18 17:44:46
  */
 
 /**
@@ -68,8 +68,10 @@ const onDisconnect = (socket) => {
 	socket.on('disconnect', function () {
 		const userId = socket.request.user.id,
 			socketId = socket.id;
+
 		console.log('\n😈 Oops! User disconnected', userId, socketId);
-		socketMap.delete(userId);
+
+		if (userId != undefined) socketMap.delete(userId);
 	});
 };
 const onSendNotice = (socket) => {
@@ -213,21 +215,12 @@ module.exports = function (io) {
 		/**
 		 * check if user successfully logged in
 		 */
-		if (socket.request.user && !socket.request.user.logged_in) {
+		if (!socket.request.user.logged_in) {
 			console.log(
 				`\n【socket.io】User not logged in try to connect socket, user: ${socket.request.user}`
 			);
-			return;
-		}
-		// for debug
-		if (socket.request.user && !socket.request.user.id) {
-			console.log(
-				`\n【socket.io】Missing user id in socket.request.user`
-			);
-			return;
-		}
-		if (socket && !socket.id) {
-			console.log(`\n【socket.io】Missing socket id in socket object`);
+			// disconnect
+			io.in(socket.id).disconnectSockets();
 			return;
 		}
 

--- a/server/configs/socket.config.js
+++ b/server/configs/socket.config.js
@@ -5,7 +5,7 @@
  * @Author: Hu Keyi
  * @Date: 2021-05-23 00:20:55
  * @Last Modified by: Hu Keyi
- * @Last Modified time: 2023-03-04 15:22:31
+ * @Last Modified time: 2023-03-18 16:28:40
  */
 
 /**
@@ -211,12 +211,33 @@ const onRoomChat = async (io, socket) => {
 module.exports = function (io) {
 	io.on('connection', async function (socket) {
 		/**
+		 * check if user successfully logged in
+		 */
+		if (socket.request.user && !socket.request.user.logged_in) {
+			console.log(
+				`\n【socket.io】User not logged in try to connect socket, user: ${socket.request.user}`
+			);
+			return;
+		}
+		// for debug
+		if (socket.request.user && !socket.request.user.id) {
+			console.log(
+				`\n【socket.io】Missing user id in socket.request.user`
+			);
+			return;
+		}
+		if (socket && !socket.id) {
+			console.log(`\n【socket.io】Missing socket id in socket object`);
+			return;
+		}
+
+		/**
 		 * 初始化socket映射表和room集合
 		 */
-
 		const userId = socket.request.user.id,
 			socketId = socket.id;
-		console.log('\n🎉 Yeah! User connected', userId, socketId);
+		console.log('\n【socket.io】🎉 Yeah! User connected', userId, socketId);
+
 		socketMap.set(userId, socketId);
 		console.log('socketMap', socketMap);
 


### PR DESCRIPTION
- When the client tries to connect a socket with the server, it has to send a cookie (`express_sid`) in the request
- Somehow the session_id stored in the cookie is not identical to what we need in searching the sessionStore, which needs a bit of workaround 【 #fixme 】
- The `cookie.httpOnly` property of express-session has to be false in order to let the client get `express_sid`